### PR TITLE
add scheduler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1593,7 +1593,7 @@ if(WITH_DEV)
   endforeach(sourcefile ${DEVELOP})
 endif()
 
-set(WITH_RDMA_SUPPORT true)
+set(WITH_RDMA_SUPPORT false)
 if(WITH_RDMA_SUPPORT)
   message(STATUS "RDMA support is enabled")
   add_definitions(-DROCKSDB_RDMA)

--- a/env/fs_posix.cc
+++ b/env/fs_posix.cc
@@ -7,6 +7,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors
 
+#include "rocksdb/env.h"
 #if !defined(OS_WIN)
 
 #include <dirent.h>
@@ -341,7 +342,7 @@ class PosixFileSystem : public FileSystem {
 #endif
       result->reset(new PosixWritableFile(
           fname, fd, GetLogicalBlockSizeForWriteIfNeeded(options, fname, fd),
-          options));
+          options, writeWindow_));
     } else {
       // disable mmap writes
       EnvOptions no_mmap_writes_options = options;
@@ -350,7 +351,7 @@ class PosixFileSystem : public FileSystem {
           new PosixWritableFile(fname, fd,
                                 GetLogicalBlockSizeForWriteIfNeeded(
                                     no_mmap_writes_options, fname, fd),
-                                no_mmap_writes_options));
+                                no_mmap_writes_options, writeWindow_));
     }
     return s;
   }
@@ -436,7 +437,7 @@ class PosixFileSystem : public FileSystem {
 #endif
       result->reset(new PosixWritableFile(
           fname, fd, GetLogicalBlockSizeForWriteIfNeeded(options, fname, fd),
-          options));
+          options, writeWindow_));
     } else {
       // disable mmap writes
       FileOptions no_mmap_writes_options = options;
@@ -445,7 +446,7 @@ class PosixFileSystem : public FileSystem {
           new PosixWritableFile(fname, fd,
                                 GetLogicalBlockSizeForWriteIfNeeded(
                                     no_mmap_writes_options, fname, fd),
-                                no_mmap_writes_options));
+                                no_mmap_writes_options, writeWindow_));
     }
     return s;
   }
@@ -938,6 +939,12 @@ class PosixFileSystem : public FileSystem {
     return Status::OK();
   }
 #endif
+
+  virtual size_t get_writein_speed() override { return writeWindow_.get(); }
+
+ private:
+  FileSystem::SlidingWindow writeWindow_;
+
  private:
   bool forceMmapOff_ = false;  // do we override Env options?
 

--- a/env/io_posix.cc
+++ b/env/io_posix.cc
@@ -7,13 +7,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
+#include "rocksdb/env.h"
 #ifdef ROCKSDB_LIB_IO_POSIX
-#include "env/io_posix.h"
-
 #include <errno.h>
 #include <fcntl.h>
 
 #include <algorithm>
+
+#include "env/io_posix.h"
 #if defined(OS_LINUX)
 #include <linux/fs.h>
 #ifndef FALLOC_FL_KEEP_SIZE
@@ -1270,8 +1271,10 @@ IOStatus PosixMmapFile::Allocate(uint64_t offset, uint64_t len,
  */
 PosixWritableFile::PosixWritableFile(const std::string& fname, int fd,
                                      size_t logical_block_size,
-                                     const EnvOptions& options)
+                                     const EnvOptions& options,
+                                     FileSystem::SlidingWindow& window)
     : FSWritableFile(options),
+      writeWindow_(window),
       filename_(fname),
       use_direct_io_(options.use_direct_writes),
       fd_(fd),

--- a/env/io_posix.h
+++ b/env/io_posix.h
@@ -327,6 +327,9 @@ class PosixRandomAccessFile : public FSRandomAccessFile {
 };
 
 class PosixWritableFile : public FSWritableFile {
+ private:
+  FileSystem::SlidingWindow& writeWindow_;
+
  protected:
   const std::string filename_;
   const bool use_direct_io_;
@@ -346,7 +349,8 @@ class PosixWritableFile : public FSWritableFile {
  public:
   explicit PosixWritableFile(const std::string& fname, int fd,
                              size_t logical_block_size,
-                             const EnvOptions& options);
+                             const EnvOptions& options,
+                             FileSystem::SlidingWindow& writeWindow);
   virtual ~PosixWritableFile();
 
   // Need to implement this so the file is truncated correctly

--- a/memory/remote_flush_service.cc
+++ b/memory/remote_flush_service.cc
@@ -7,6 +7,7 @@
 #include <infiniband/verbs.h>
 #include <inttypes.h>
 #include <netdb.h>
+#include <poll.h>
 #include <stdint.h>
 #include <sys/select.h>
 #include <sys/socket.h>
@@ -140,6 +141,8 @@ bool RemoteFlushJobPD::closetcp() {
 }
 
 bool RemoteFlushJobPD::opentcp(int port) {
+  std::thread listen_thread{[this]() { pd_.listen(); }};
+  listen_thread.detach();
   if (server_info_.tcp_server_sockfd_ != -1) {
     LOG("tcp server already opened");
     return false;
@@ -238,6 +241,34 @@ void RemoteFlushJobPD::setfree_flush_job_executor(TCPNode *worker_node) {
 }
 TCPNode *RemoteFlushJobPD::choose_flush_job_executor() {
   std::lock_guard<std::mutex> lock(mtx_);
+  if (!pd_.available_workers_.empty()) {
+    TCPNode *choose_by_policy = nullptr;
+    choose_by_policy = pd_.available_workers_.front();
+    pd_.available_workers_.pop();
+    int client_sockfd = socket(AF_INET, SOCK_STREAM, 0);
+    assert(client_sockfd != -1);
+    char choose_client_ip[INET_ADDRSTRLEN];
+    inet_ntop(AF_INET, &choose_by_policy->connection_info_.sin_addr.sin_addr,
+              choose_client_ip, INET_ADDRSTRLEN);
+    LOG_CERR("MemNode send package to worker: ", client_ip);
+
+    // find TCPNode by ip
+    for (auto &it : flush_job_executors_status_) {
+      char client_ip[INET_ADDRSTRLEN];
+      inet_ntop(AF_INET, &it.first->connection_info_.sin_addr.sin_addr,
+                client_ip, INET_ADDRSTRLEN);
+      if (strcmp(client_ip, choose_client_ip) == 0 && it.second == true) {
+        it.second = false;
+        it.first->connection_info_.client_sockfd = client_sockfd;
+        flush_job_executors_in_use_.insert(
+            std::make_pair(client_sockfd, it.first));
+        return it.first;
+      }
+    }
+    // not found
+    printf("chosen worker not found, fallback to default\n");
+  }
+
   int client_sockfd = socket(AF_INET, SOCK_STREAM, 0);
   assert(client_sockfd != -1);
   for (auto &it : flush_job_executors_status_) {
@@ -347,13 +378,14 @@ std::vector<struct RDMANode::rdma_connection *> RDMANode::sock_connect(
 sock_connect_exit:
   if (listenfd) close(listenfd);
   if (resolved_addr) freeaddrinfo(resolved_addr);
-  if (successful_conn.size() <= 0)
-    if (servername)
+  if (successful_conn.size() <= 0) {
+    if (servername) {
       fprintf(stderr, "Couldn't connect to %s:%d\n", servername, port);
-    else {
+    } else {
       perror("server accept");
       fprintf(stderr, "accept() failed\n");
     }
+  }
   return successful_conn;
 }
 
@@ -513,7 +545,7 @@ int RDMANode::resources_create(size_t size) {
   }
   // LOG("found %d device(s)\n", num_devices);
   // search for the specific device we want to work with
-  for (i = 0; i < (size_t)num_devices; i++) {
+  for (i = 0; i < num_devices; i++) {
     if (config.dev_name == "") {
       config.dev_name = std::string(strdup(ibv_get_device_name(dev_list[i])));
       // LOG("device not specified, using first one found: %s\n",
@@ -1168,6 +1200,120 @@ bool RDMAServer::service(struct rdma_connection *conn) {
       fprintf(stderr, "Unknown request type from client: %d\n", req_type);
   }
   return true;
+}
+
+TCPNode *PlacementDriver::choose_worker(const placement_info &info) {
+  double base =
+      1.0 * info.current_background_job_num_ / max_background_job_num_ +
+      1.0 * info.current_hdfs_io_ / max_hdfs_io_;
+  TCPNode *choose = nullptr;
+  for (auto &worker : workers_) {
+    auto val = peers_.at(worker);
+    double cal =
+        1.0 * val.current_background_job_num_ / max_background_job_num_ +
+        1.0 * val.current_hdfs_io_ / max_hdfs_io_;
+    if (cal < base) {
+      base = cal;
+      choose = worker;
+    }
+  }
+  return choose;
+}
+
+void PlacementDriver::step(bool from_generator, size_t id,
+                           placement_info info) {
+  if (from_generator) {
+    // handle MsgFlushRequest
+    assert(peers_.find(generators_[id - 1]) != peers_.end());
+    peers_.at(generators_[id - 1]) = info;
+    TCPNode *worker = choose_worker(info);
+    if (worker == nullptr) {
+      // fallback to local flush
+      bool admit = false;
+      generators_[id - 1]->send(&admit, sizeof(bool));
+    } else {
+      bool admit = true;
+      generators_[id - 1]->send(&admit, sizeof(bool));
+      available_workers_.push(worker);
+      peers_.at(worker).current_background_job_num_++;
+    }
+  } else {
+    // handle MsgHeartBeat
+    assert(peers_.find(workers_[id - 1]) != peers_.end());
+    peers_.at(workers_[id - 1]) = info;
+  }
+}
+void PlacementDriver::listen() {
+  std::vector<struct pollfd> pollfds;
+  for (auto &node : workers_) {
+    pollfds.push_back({});
+    pollfds.back().fd = node->connection_info_.client_sockfd;
+    pollfds.back().events = POLLIN;
+  }
+  for (auto &node : generators_) {
+    pollfds.push_back({});
+    pollfds.back().fd = node->connection_info_.client_sockfd;
+    pollfds.back().events = POLLIN;
+  }
+
+  while (true) {
+    int ret = poll(pollfds.data(), pollfds.size(), -1);
+    if (ret < 0) {
+      fprintf(stderr, "Poll error\n");
+      return;
+    }
+    for (int i = 0; i < (int)pollfds.size(); i++) {
+      if (pollfds[i].revents & POLLIN) {
+        if (i < (int)workers_.size()) {
+          placement_info val;
+          ssize_t bytesRead = recv(pollfds[i].fd, &val, sizeof(val), 0);
+          if (bytesRead == -1) {
+            printf("recv");
+            assert(false);
+          } else if (bytesRead == 0) {
+            printf("Connection closed by remote peer.\n");
+            assert(false);
+          }
+          std::thread thread([this, i, val]() { step(false, i + 1, val); });
+          thread.detach();
+        } else {
+          placement_info val;
+          ssize_t bytesRead = recv(pollfds[i].fd, &val, sizeof(val), 0);
+          if (bytesRead == -1) {
+            printf("recv failed.\n");
+            assert(false);
+          } else if (bytesRead == 0) {
+            printf("Connection closed by remote peer.\n");
+            assert(false);
+          }
+          std::thread thread(
+              [this, i, val]() { step(true, i - workers_.size() + 1, val); });
+          thread.detach();
+        }
+      }
+    }
+  }
+}
+
+TCPNode *PlacementDriver::connect_peers(const std::string &ip, int port) {
+  int sock = socket(AF_INET, SOCK_STREAM, 0);
+  if (sock < 0) {
+    fprintf(stderr, "Failed creating socket\n");
+    return nullptr;
+  }
+  struct sockaddr_in serv_addr;
+  serv_addr.sin_family = AF_INET;
+  serv_addr.sin_port = htons(port);
+  if (inet_pton(AF_INET, ip.c_str(), &serv_addr.sin_addr) <= 0) {
+    fprintf(stderr, "Invalid address\n");
+    return nullptr;
+  }
+  if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+    fprintf(stderr, "Failed connecting to server\n");
+    return nullptr;
+  }
+  auto node = new TCPNode(serv_addr, sock);
+  return node;
 }
 
 }  // namespace ROCKSDB_NAMESPACE

--- a/memory/tcp_server.cc
+++ b/memory/tcp_server.cc
@@ -40,7 +40,10 @@ int main(int argc, char** argv) {
   rocksdb::RemoteFlushJobPD& memnode = rocksdb::RemoteFlushJobPD::Instance();
   // TODO(rdma): change this on your machine
   memnode.register_flush_job_executor("127.0.0.1", 9092);
-  memnode.register_flush_job_executor("127.0.0.1", 9093);
+
+  memnode.pd_add_generator("127.0.0.1", 10086);
+  memnode.pd_add_worker("executor's ip", 10086);
+
   memnode.opentcp(port);
   while (true) {
     std::string command;

--- a/plugin/hdfs/env_hdfs.h
+++ b/plugin/hdfs/env_hdfs.h
@@ -5,6 +5,8 @@
 
 #pragma once
 
+#include <mutex>
+
 #include "hdfs.h"
 #include "rocksdb/env.h"
 #include "rocksdb/file_system.h"
@@ -89,6 +91,7 @@ class HdfsFileSystem : public FileSystemWrapper {
                        IODebugContext* /*dbg*/) override;
 
  private:
+  FileSystem::SlidingWindow writeWindow_;
   std::string fsname_;  // string of the form "hdfs://hostname:port/dira"
   hdfsFS fileSys_;      // a single hdfsFS object for all files
 };


### PR DESCRIPTION
#### Adding Scheduler: 
* The scheduler will receive two types of messages: MsgHeartBeat sent by compute nodes and MsgFlushRequest generated  by rocksdb instance when flush tasks occur. 
* Both types of messages include the fields **current_background_job_num_** and **current_hdfs_io_**, representing the current number of background tasks and the rate at which the node is writing to HDFS, respectively. 
* To quantify each node's write workload, use **val = current_background_job_num_ / max_background_job_num + current_hdfs_io_ / max_hdfs_io_** to calculate a comparative value.

* the procedure looks like this:
<img width="523" alt="image" src="https://github.com/asu-idi/rocksdb_remote_flush_rdma/assets/112808063/11cbcc79-ebde-40ea-8240-2952382adba2">



* To calculate the HDFS write load, we collect write_size when the low-level file system write interface, HDFSWritableFile::Write(), is called.
* The weight values such as max_hdfs_io may need further adjustment based on experimental results.